### PR TITLE
IssuedCredential support String or Json representations plus additona…

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -23,18 +23,29 @@ import eu.europa.ec.eudi.openid4vci.internal.ClaimSetSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
+/**
+ * Represents the credential as it is serialized by the credential issuer
+ * within a credential or deferred response.
+ *
+ * The choice is format-specific, and it can be either a string or a JSON object
+ */
 sealed interface Credential {
     @JvmInline
-    value class Str(val value: String) : Credential
+    value class Str(val value: String) : Credential {
+        override fun toString(): String = value
+    }
 
     @JvmInline
-    value class Json(val value: JsonObject) : Credential
+    value class Json(val value: JsonObject) : Credential {
+        override fun toString(): String = value.toString()
+    }
 }
 
 /**
  *  Credential was issued from server and the result is returned inline.
  *
  * @param credential The issued credential.
+ * @param additionalInfo Optional, information returned by the issuer for the [credential]
  */
 data class IssuedCredential(
     val credential: Credential,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -21,6 +21,15 @@ import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory
 import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.internal.ClaimSetSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+sealed interface Credential {
+    @JvmInline
+    value class Str(val value: String) : Credential
+
+    @JvmInline
+    value class Json(val value: JsonObject) : Credential
+}
 
 /**
  *  Credential was issued from server and the result is returned inline.
@@ -28,8 +37,17 @@ import kotlinx.serialization.Serializable
  * @param credential The issued credential.
  */
 data class IssuedCredential(
-    val credential: String,
-) : java.io.Serializable
+    val credential: Credential,
+    val additionalInfo: JsonObject?,
+) : java.io.Serializable {
+    companion object {
+        fun string(credential: String, additionalInfo: JsonObject? = null): IssuedCredential =
+            IssuedCredential(Credential.Str(credential), additionalInfo)
+
+        fun json(credential: JsonObject, additionalInfo: JsonObject? = null): IssuedCredential =
+            IssuedCredential(Credential.Json(credential), additionalInfo)
+    }
+}
 
 /**
  * Sealed hierarchy of states describing the state of an issuance request submitted to a credential issuer.

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -22,6 +22,8 @@ import io.ktor.http.content.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.fail
@@ -42,11 +44,11 @@ class IssuanceBatchRequestTest {
                         encryptedResponseDataBuilder(it) {
                             Json.encodeToString(
                                 CredentialResponseSuccessTO(
-                                    credentials = listOf(
-                                        "issued_credential_content_mso_mdoc0",
-                                        "issued_credential_content_mso_mdoc1",
-                                        "issued_credential_content_mso_mdoc2",
-                                    ),
+                                    credentials = buildJsonArray {
+                                        add("issued_credential_content_mso_mdoc0")
+                                        add("issued_credential_content_mso_mdoc1")
+                                        add("issued_credential_content_mso_mdoc2")
+                                    },
                                     cNonce = "wlbQc6pCJp",
                                     cNonceExpiresInSeconds = 86400,
                                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -22,16 +22,23 @@ import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
-import eu.europa.ec.eudi.openid4vci.internal.http.*
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialResponseSuccessTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.util.*
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class IssuanceEncryptedResponsesTest {
 
@@ -259,7 +266,7 @@ class IssuanceEncryptedResponsesTest {
                         encryptedResponseDataBuilder(it) {
                             Json.encodeToString(
                                 CredentialResponseSuccessTO(
-                                    credential = "issued_credential",
+                                    credential = JsonPrimitive("issued_credential"),
                                     notificationId = "fgh126lbHjtspVbn",
                                     cNonce = "wlbQc6pCJp",
                                     cNonceExpiresInSeconds = 86400,
@@ -336,9 +343,9 @@ class IssuanceEncryptedResponsesTest {
                         encryptedResponseDataBuilder(it) {
                             Json.encodeToString(
                                 CredentialResponseSuccessTO(
-                                    credentials = listOf(
-                                        "${PID_MsoMdoc}_issued_credential",
-                                    ),
+                                    credentials = buildJsonArray {
+                                        add("${PID_MsoMdoc}_issued_credential")
+                                    },
                                     cNonce = "wlbQc6pCJp",
                                     cNonceExpiresInSeconds = 86400,
                                 ),
@@ -396,7 +403,7 @@ class IssuanceEncryptedResponsesTest {
                         encryptedResponseDataBuilder(it) {
                             Json.encodeToString(
                                 CredentialResponseSuccessTO(
-                                    credentials = listOf("${PID_MsoMdoc}_issued_credential"),
+                                    credentials = buildJsonArray { add("${PID_MsoMdoc}_issued_credential") },
                                     cNonce = "wlbQc6pCJp",
                                     cNonceExpiresInSeconds = 86400,
                                 ),


### PR DESCRIPTION
This PR adds to draft14 the ability to handle issued credentials in the form of either a String or/and JsonObject.

To support this a new sealed hierarchy was introduced Credential having two members Str and Json.
In addition, IssuedCredential the "val addiationalInformation: JsonObject?" to support the extensibility requirements of d15.

Relates to https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-openid4vci-kt/issues/320
